### PR TITLE
OHT-37 Hide the resource_license section which is a bug

### DIFF
--- a/ckanext/oht/templates/package/resource_read.html
+++ b/ckanext/oht/templates/package/resource_read.html
@@ -1,0 +1,6 @@
+{% ckan_extends %}
+{% block secondary_content %}
+  {% block resources_list %}
+    {% snippet "package/snippets/resources.html", pkg=pkg, active=res.id, action='read', is_activity_archive=is_activity_archive %}
+  {% endblock %}
+{% endblock %}


### PR DESCRIPTION
This PR removes the resource_license section from the ckan core template:
https://github.com/ckan/ckan/blob/7586d78682c30f205027522214f33ee2bf413055/ckan/templates/package/resource_read.html#L212

The name of this block causes a conflict with another block somewhere.  I am unsure where the block is defined.  It may be with ckanext-scheming here: 
https://github.com/ckan/ckan/blob/7586d78682c30f205027522214f33ee2bf413055/ckan/templates/package/resource_read.html#L212

The result is the strange appearance of unformatted license informion in the side column like this:
![image](https://user-images.githubusercontent.com/8988344/174602762-057745fe-3e92-4e52-bd59-89fe25d113f7.png)

The approach in this PR is simply to remove the `{% block resource_license %}` as we don't need the social content to appear. 

A fix should be ported to DMS and ADR. We should also discuss whether it is a appropriate to take this bug up with core ckan. 