### PR TITLE
SPC-79 dataset duplicate

### DIFF
--- a/ckanext/spectrum/actions.py
+++ b/ckanext/spectrum/actions.py
@@ -24,6 +24,7 @@ def dataset_duplicate(context, data_dict):
     dataset_id = dataset['id']
     resources = dataset.pop('resources', [])
 
+    del dataset['id']
     del dataset['name']
     del data_dict['id']
     del context['package']

--- a/ckanext/spectrum/actions.py
+++ b/ckanext/spectrum/actions.py
@@ -24,10 +24,10 @@ def dataset_duplicate(context, data_dict):
     dataset_id = dataset['id']
     resources = dataset.pop('resources', [])
 
-    del dataset['id']
-    del dataset['name']
-    del data_dict['id']
-    del context['package']
+    dataset.pop('id', None)
+    dataset.pop('name', None)
+    data_dict.pop('id', None)
+    context.pop('package', None)
 
     dataset = {**dataset, **data_dict}
     new_dataset = toolkit.get_action('package_create')(context, dataset)
@@ -42,11 +42,11 @@ def dataset_duplicate(context, data_dict):
         resource['upload'] = _get_resource_upload(dataset_id, resource['id'], filename)
         resource['package_id'] = new_dataset['id']
 
-        del resource['id']
-        del resource['size']
-        del resource['sha256']
-        del resource['lfs_prefix']
-        del resource['url']
+        resource.pop('id', None)
+        resource.pop('size', None)
+        resource.pop('sha256', None)
+        resource.pop('lfs_prefix', None)
+        resource.pop('url', None)
 
         toolkit.get_action('resource_create')(context, resource)
 

--- a/ckanext/spectrum/actions.py
+++ b/ckanext/spectrum/actions.py
@@ -1,5 +1,9 @@
 import ckan.plugins.toolkit as toolkit
+from ckanext.blob_storage.blueprints import download
+from werkzeug.datastructures import FileStorage
+from io import BytesIO
 import secrets
+import requests
 
 
 @toolkit.chained_action
@@ -15,8 +19,9 @@ def user_create(next_action, context, data_dict):
 
 
 def dataset_duplicate(context, data_dict):
-    dataset_id = toolkit.get_or_bust(data_dict, 'id')
-    dataset = toolkit.get_action('package_show')(context, {'id': dataset_id})
+    dataset_id_or_name = toolkit.get_or_bust(data_dict, 'id')
+    dataset = toolkit.get_action('package_show')(context, {'id': dataset_id_or_name})
+    dataset_id = dataset['id']
     resources = dataset.pop('resources', [])
 
     del dataset['id']
@@ -28,7 +33,18 @@ def dataset_duplicate(context, data_dict):
     new_dataset = toolkit.get_action('package_create')(context, dataset)
 
     for resource in resources:
+        filename = resource.get('url', "").split('/')[-1]
+        blob_storage_response = download(dataset_id, resource['id'], filename)
+        file_response = requests.get(blob_storage_response.headers.get('Location'), stream=True)
+        file_object = FileStorage(BytesIO(file_response.content), filename, 'upload')
+
+        del resource['size']
+        del resource['sha256']
+        del resource['lfs_prefix']
+        del resource['url']
+
         resource['package_id'] = new_dataset['id']
+        resource['upload'] = file_object
         toolkit.get_action('resource_create')(context, resource)
 
     return toolkit.get_action('package_show')(context, {'id': new_dataset['id']})

--- a/ckanext/spectrum/actions.py
+++ b/ckanext/spectrum/actions.py
@@ -12,3 +12,23 @@ def user_create(next_action, context, data_dict):
         data_dict['password'] = secrets.token_urlsafe(32)
 
     return next_action(context, data_dict)
+
+
+def dataset_duplicate(context, data_dict):
+    dataset_id = toolkit.get_or_bust(data_dict, 'id')
+    dataset = toolkit.get_action('package_show')(context, {'id': dataset_id})
+    resources = dataset.pop('resources', [])
+
+    del dataset['id']
+    del dataset['name']
+    del data_dict['id']
+    del context['package']
+
+    dataset = {**dataset, **data_dict}
+    new_dataset = toolkit.get_action('package_create')(context, dataset)
+
+    for resource in resources:
+        resource['package_id'] = new_dataset['id']
+        toolkit.get_action('resource_create')(context, resource)
+
+    return toolkit.get_action('package_show')(context, {'id': new_dataset['id']})

--- a/ckanext/spectrum/actions.py
+++ b/ckanext/spectrum/actions.py
@@ -21,9 +21,7 @@ def user_create(next_action, context, data_dict):
 def dataset_duplicate(context, data_dict):
     dataset_id_or_name = toolkit.get_or_bust(data_dict, 'id')
     dataset = toolkit.get_action('package_show')(context, {'id': dataset_id_or_name})
-
     dataset_id = dataset['id']
-    resources = dataset.pop('resources', [])
 
     dataset.pop('id', None)
     dataset.pop('name', None)
@@ -31,6 +29,8 @@ def dataset_duplicate(context, data_dict):
     context.pop('package', None)
 
     dataset = {**dataset, **data_dict}
+    resources = dataset.pop('resources', [])
+
     new_dataset = toolkit.get_action('package_create')(context, dataset)
     toolkit.get_action('package_relationship_create')(context, {
         'subject': new_dataset['id'],

--- a/ckanext/spectrum/actions.py
+++ b/ckanext/spectrum/actions.py
@@ -31,6 +31,11 @@ def dataset_duplicate(context, data_dict):
 
     dataset = {**dataset, **data_dict}
     new_dataset = toolkit.get_action('package_create')(context, dataset)
+    toolkit.get_action('package_relationship_create')(context, {
+        'subject': new_dataset['id'],
+        'object': dataset_id,
+        'type': 'child_of'
+    })
 
     for resource in resources:
         resource['upload'] = _get_resource_file_storage(dataset_id, resource)

--- a/ckanext/spectrum/plugin.py
+++ b/ckanext/spectrum/plugin.py
@@ -96,7 +96,8 @@ class SpectrumPlugin(plugins.SingletonPlugin, DefaultPermissionLabels):
     # IActions
     def get_actions(self):
         return {
-            'user_create': spectrum_actions.user_create
+            'user_create': spectrum_actions.user_create,
+            'dataset_duplicate': spectrum_actions.dataset_duplicate
         }
 
     # IValidators

--- a/ckanext/spectrum/tests/test_actions.py
+++ b/ckanext/spectrum/tests/test_actions.py
@@ -92,37 +92,39 @@ def mock_file():
 @pytest.mark.usefixtures('clean_db', 'with_plugins')
 class TestDatasetDuplicate():
 
-    @pytest.mark.parametrize('field', [
-        'title', 'notes', 'private', 'num_resources'
-    ])
-    def test_dataset_metadata_duplicated(self, field, dataset, mock_file):
+    def test_dataset_metadata_duplicated(self, dataset, mock_file):
         result = call_action(
             'dataset_duplicate',
             id=dataset['id'],
             name="duplicated-dataset"
         )
-        assert result[field] == dataset[field]
+        fields = ['title', 'notes', 'private', 'num_resources']
+        duplicated = [result[field] == dataset[field] for field in fields]
+        assert all(duplicated), f"Duplication failed: {zip(fields, duplicated)}"
 
-    @pytest.mark.parametrize('field', ['name', 'id'])
-    def test_dataset_metadata_not_duplicated(self, field, dataset, mock_file):
+    def test_dataset_metadata_not_duplicated(self, dataset, mock_file):
         result = call_action(
             'dataset_duplicate',
             id=dataset['id'],
             name="duplicated-dataset"
         )
-        assert result[field] != dataset[field]
+        fields = ['name', 'id']
+        not_duplicated = [result[field] != dataset[field] for field in fields]
+        assert all(not_duplicated), f"Duplication occured: {zip(fields, not_duplicated)}"
 
-    @pytest.mark.parametrize('field', ['name'])
-    def test_resource_metadata_duplicated(self, field, dataset, mock_file):
+    def test_resource_metadata_duplicated(self, dataset, mock_file):
         result = call_action(
             'dataset_duplicate',
             id=dataset['id'],
             name="duplicated-dataset"
         )
         assert len(dataset['resources']) == len(result['resources'])
+        fields = ['name']
+
         for i in range(len(dataset['resources'])):
-            duplicated = dataset['resources'][i][field] == result['resources'][i][field]
-            assert duplicated, f"Field {field} did not duplicate for resource {i}"
+            for f in fields:
+                duplicated = dataset['resources'][i][f] == result['resources'][i][f]
+                assert duplicated, f"Field {f} did not duplicate for resource {i}"
 
     def test_dataset_not_found(self, mock_file):
         with pytest.raises(toolkit.ObjectNotFound):

--- a/ckanext/spectrum/tests/test_actions.py
+++ b/ckanext/spectrum/tests/test_actions.py
@@ -5,6 +5,8 @@ from ckan.tests.helpers import call_action
 from ckanext.spectrum.actions import user_create
 import ckan.tests.factories as factories
 from ckanext.spectrum.tests import get_context
+from werkzeug.datastructures import FileStorage
+from io import StringIO
 
 
 DUMMY_PASSWORD = '01234567890123456789012345678901'
@@ -81,13 +83,20 @@ def dataset():
     return call_action('package_show', id=dataset['id'])
 
 
+@pytest.fixture
+def mock_file():
+    function_name = "ckanext.spectrum.actions._get_resource_upload"
+    with mock.patch(function_name, return_value=None):
+        yield
+
+
 @pytest.mark.usefixtures('clean_db', 'with_plugins')
 class TestDatasetDuplicate():
 
     @pytest.mark.parametrize('field', [
         'title', 'notes', 'private', 'num_resources'
     ])
-    def test_dataset_metadata_duplicated(self, field, dataset):
+    def test_dataset_metadata_duplicated(self, field, dataset, mock_file):
         result = call_action(
             'dataset_duplicate',
             id=dataset['id'],
@@ -96,7 +105,7 @@ class TestDatasetDuplicate():
         assert result[field] == dataset[field]
 
     @pytest.mark.parametrize('field', ['name', 'id'])
-    def test_dataset_metadata_not_duplicated(self, field, dataset):
+    def test_dataset_metadata_not_duplicated(self, field, dataset, mock_file):
         result = call_action(
             'dataset_duplicate',
             id=dataset['id'],
@@ -105,7 +114,7 @@ class TestDatasetDuplicate():
         assert result[field] != dataset[field]
 
     @pytest.mark.parametrize('field', ['name'])
-    def test_resource_metadata_duplicated(self, field, dataset):
+    def test_resource_metadata_duplicated(self, field, dataset, mock_file):
         result = call_action(
             'dataset_duplicate',
             id=dataset['id'],

--- a/ckanext/spectrum/tests/test_actions.py
+++ b/ckanext/spectrum/tests/test_actions.py
@@ -5,8 +5,7 @@ from ckan.tests.helpers import call_action
 from ckanext.spectrum.actions import user_create
 import ckan.tests.factories as factories
 from ckanext.spectrum.tests import get_context
-from werkzeug.datastructures import FileStorage
-from io import StringIO
+from ckan.plugins import toolkit
 
 
 DUMMY_PASSWORD = '01234567890123456789012345678901'
@@ -124,3 +123,11 @@ class TestDatasetDuplicate():
         for i in range(len(dataset['resources'])):
             duplicated = dataset['resources'][i][field] == result['resources'][i][field]
             assert duplicated, f"Field {field} did not duplicate for resource {i}"
+
+    def test_dataset_not_found(self, mock_file):
+        with pytest.raises(toolkit.ObjectNotFound):
+            call_action(
+                'dataset_duplicate',
+                id='non-existant-id',
+                name="duplicated-dataset"
+            )

--- a/ckanext/spectrum/tests/test_actions.py
+++ b/ckanext/spectrum/tests/test_actions.py
@@ -133,3 +133,18 @@ class TestDatasetDuplicate():
                 id='non-existant-id',
                 name="duplicated-dataset"
             )
+
+    @pytest.mark.parametrize('key, value', [
+        ('notes', 'Some new notes'),
+        ('title', 'A new title'),
+        ('private', True),
+        ('resources', [])
+    ])
+    def test_metadata_overidden(self, key, value, mock_file, dataset):
+        data_dict = {
+            'id': dataset['id'],
+            'name': "duplicated-dataset",
+            key: value
+        }
+        result = call_action('dataset_duplicate', **data_dict)
+        assert result[key] == value

--- a/ckanext/spectrum/upload.py
+++ b/ckanext/spectrum/upload.py
@@ -10,7 +10,8 @@ log = logging.getLogger(__name__)
 
 
 def add_activity(context, data_dict, activity_type):
-    user_id = context['model'].User.by_name(context['user']).id
+    user = context['model'].User.by_name(context['user'])
+    user_id = getattr(user, 'id', "UnknownUser")
     package = context.get("package", context['model'].Package.get(data_dict["name"]))
     activity = package.activity_stream_item(activity_type, user_id)
     context['session'].add(activity)


### PR DESCRIPTION
ToDo:

- [x] Proof of concept of fairly high-level dataset duplication for spectrum-ckan. 
- [x] Decide how to record the duplication.  At the moment I have created a package relationship, because it was simple.  But this is an unused, under developed feature that isn't properly maintained at the moment. Preferred alternative would be to create a special type of activity for the activity stream. This is not simple.  More information [here](https://github.com/ckan/ckan/issues/5865).
- [x] Mock file reading for metadata duplication tests.
- [ ] Unit tests for data file reading/duplication - this is NOT done.  I've deemed it such a complex task that it is not worth the effort at this stage. 
- [ ] Generalise datafile copying to CKAN instances not using ckanext-blob-storage
- [x] Refactor and cleanup
