### PR TITLE
SPC-79 Improve dataset_duplication

### DIFF
--- a/ckanext/spectrum/tests/test_actions.py
+++ b/ckanext/spectrum/tests/test_actions.py
@@ -161,7 +161,7 @@ class TestDatasetDuplicate():
             id=dataset1['id'],
             id2=dataset2['id']
         )
-        assert relationships_list[0]['subject'] == 'test_dataset_00'
+        assert relationships_list[0]['subject'] == dataset1['name']
         assert relationships_list[0]['type'] == 'parent_of'
-        assert relationships_list[0]['object'] == 'test_dataset_01'
+        assert relationships_list[0]['object'] == dataset2['name']
         assert relationships_list[0]['comment'].startswith('Duplicated from activity ')


### PR DESCRIPTION
After further review I think that we don't actually need to duplicate data in giftless.  It was a red herring thing that we couldn't take this approach.  Testing seems to work fine now. I will merge and tell Avenir to let me know if there are any problems.  We can always revert if needbe. 