### PR TITLE
SPC-87 Lock API down to be only used by sysadmins

### DIFF
--- a/ckanext/spectrum/plugin.py
+++ b/ckanext/spectrum/plugin.py
@@ -126,10 +126,10 @@ class SpectrumPlugin(plugins.SingletonPlugin, DefaultPermissionLabels):
         """
 
         if toolkit.request.path.startswith('/api/'):
-            # Not ideal, but this private import is the only way to use core CKAN logic.
+            # Private import is only way to set g.userobj using core CKAN.
             _identify_user_default()
 
-            if not is_sysadmin(getattr(toolkit.g, 'user', '')):
+            if not toolkit.g.userobj or not toolkit.g.userobj.sysadmin:
                 return {
                     "success": False,
                     "error": {

--- a/ckanext/spectrum/plugin.py
+++ b/ckanext/spectrum/plugin.py
@@ -4,6 +4,7 @@ import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 import ckan.lib.uploader as uploader
 from ckan.views import _identify_user_default
+from ckan.authz import is_sysadmin
 import ckanext.blob_storage.helpers as blobstorage_helpers
 from ckan.lib.plugins import DefaultPermissionLabels
 from ckanext.spectrum.helpers import (
@@ -14,7 +15,7 @@ import ckanext.spectrum.authn as spectrum_authn
 import ckanext.spectrum.upload as spectrum_upload
 import ckanext.spectrum.actions as spectrum_actions
 import ckanext.spectrum.validators as spectrum_validators
-from flask import request
+
 
 log = logging.getLogger(__name__)
 
@@ -124,11 +125,11 @@ class SpectrumPlugin(plugins.SingletonPlugin, DefaultPermissionLabels):
         username or user id of another CKAN user.
         """
 
-        if request.path.startswith('/api/'):
+        if toolkit.request.path.startswith('/api/'):
             # Not ideal, but this private import is the only way to use core CKAN logic.
             _identify_user_default()
 
-            if not getattr(toolkit.g.userobj, 'sysadmin', False):
+            if not is_sysadmin(getattr(toolkit.g, 'user', '')):
                 return {
                     "success": False,
                     "error": {

--- a/ckanext/spectrum/tests/test_authn.py
+++ b/ckanext/spectrum/tests/test_authn.py
@@ -28,6 +28,27 @@ class TestSysadminsOnlyCanAccessAPI():
             }
         }
 
+    @pytest.mark.parametrize('action', [
+        ('user_show'),
+        ('package_list'),
+        ('package_search'),
+        ('user_list'),
+        ('dataset_duplicate'),
+        ('user_create')
+    ])
+    def test_api_endpoints_require_registered_user(self, app, action):
+        response = app.get(
+            toolkit.url_for('api.action', ver=3, logic_function=action),
+        )
+        assert response.status_code == 403
+        assert response.json == {
+            'success': False,
+            'error': {
+                '__type': 'Not Authorized',
+                'message': "Must be a system administrator."
+            }
+        }
+
 
 @pytest.mark.usefixtures("clean_db")
 class TestSubstituteUser():


### PR DESCRIPTION
This PR locks down the API to only sysadmin users. 

The aim would then be to put the UI only behind basic auth, and leave the API exposed to the open world. 

The nice thing about this approach is that the UI continues to work smoothly as API calls in the UI are made server side using the `get_action()` function. These API calls bypass our code in identify() since the `flask.request.path` does not begin with `/api/`

I looked at the way UNHCR achieved this.  It was orders of magnitude more complicated, with a lot of further logic and code we would have to maintain. Maybe 40-50 lines spread across 3-4 functions in 2-3 modules. The change in this PR is very nearly a one liner.  I'd like to give it a go, unless someone can clearly see a problem with it. 

@tomeksabala Would value your review on this. I believe that this resolves both the concern around being able to remove basic_auth from the api, as well as the concern around being able to know that your API key is a valid api key.
