### PR TITLE
SPC-88 Allow duplicate emails

### DIFF
--- a/ckanext/spectrum/actions.py
+++ b/ckanext/spectrum/actions.py
@@ -1,20 +1,10 @@
 import ckan.plugins.toolkit as toolkit
 import secrets
 import logging
+import re
+import random
 
 log = logging.getLogger(__name__)
-
-
-@toolkit.chained_action
-def user_create(next_action, context, data_dict):
-    """
-    Autogenerates a password (if password is not provided).
-    """
-
-    if not data_dict.get('password'):
-        data_dict['password'] = secrets.token_urlsafe(32)
-
-    return next_action(context, data_dict)
 
 
 def dataset_duplicate(context, data_dict):
@@ -37,6 +27,29 @@ def dataset_duplicate(context, data_dict):
     _record_dataset_duplication(dataset_id, duplicate_dataset['id'], context)
 
     return toolkit.get_action('package_show')(context, {'id': duplicate_dataset['id']})
+
+
+@toolkit.chained_action
+def user_create(next_action, context, data_dict):
+    """
+    Autogenerates a password and username (if password or username is not provided).
+    """
+
+    if not data_dict.get('password'):
+        data_dict['password'] = secrets.token_urlsafe(32)
+
+    if data_dict.get('name'):
+        return next_action(context, data_dict)
+
+    if not data_dict.get('email'):
+        raise toolkit.ValidationError(toolkit._("Must specify either a name or an email"))
+
+    email = data_dict['email']
+    username = _get_random_username_from_email(email, context['model'])
+
+    data_dict['name'] = username
+
+    return next_action(context, data_dict)
 
 
 def _record_dataset_duplication(dataset_id, new_dataset_id, context):
@@ -63,3 +76,35 @@ def _record_dataset_duplication(dataset_id, new_dataset_id, context):
     except Exception as e:
         log.error(f"Failed to record duplication of {dataset_id} to {new_dataset_id} ...")
         log.exception(e)
+
+
+def _get_random_username_from_email(email, model):
+    """
+    This function is copied from a CKAN core private function:
+        ckan.logic.action.create._get_random_username_from_email
+    Github permalink:
+        https://github.com/ckan/ckan/blob/0a596b8394dbf9582902853ad91450d2c0d7959b/ckan/logic/action/create.py#L1102-L1116
+
+    The function has been deployed and used across a plethora of CKAN
+    instances, which is why we are adopting it here.
+
+    WARNING: This logic reveals part of the user's email address
+    as their username.  Fjelltopp recommends overriding this logic
+    for public CKAN instances. Use the IEmailAsUsername plugin
+    interface to do this.
+    """
+
+    localpart = email.split('@')[0]
+    cleaned_localpart = re.sub(r'[^\w]', '-', localpart).lower()
+
+    # if we can't create a unique user name within this many attempts
+    # then something else is probably wrong and we should give up
+    max_name_creation_attempts = 100
+
+    for i in range(max_name_creation_attempts):
+        random_number = random.SystemRandom().random() * 10000
+        name = '%s-%d' % (cleaned_localpart, random_number)
+        if not model.User.get(name):
+            return name
+
+    return cleaned_localpart

--- a/ckanext/spectrum/actions.py
+++ b/ckanext/spectrum/actions.py
@@ -46,7 +46,6 @@ def user_create(next_action, context, data_dict):
 
     email = data_dict['email']
     username = _get_random_username_from_email(email, context['model'])
-
     data_dict['name'] = username
 
     return next_action(context, data_dict)

--- a/ckanext/spectrum/actions.py
+++ b/ckanext/spectrum/actions.py
@@ -89,8 +89,7 @@ def _get_random_username_from_email(email, model):
 
     WARNING: This logic reveals part of the user's email address
     as their username.  Fjelltopp recommends overriding this logic
-    for public CKAN instances. Use the IEmailAsUsername plugin
-    interface to do this.
+    for public CKAN instances.
     """
 
     localpart = email.split('@')[0]

--- a/ckanext/spectrum/plugin.py
+++ b/ckanext/spectrum/plugin.py
@@ -106,7 +106,8 @@ class SpectrumPlugin(plugins.SingletonPlugin, DefaultPermissionLabels):
     # IValidators
     def get_validators(self):
         return {
-            'auto_generate_name_from_title': spectrum_validators.generate_name_from_title
+            'auto_generate_name_from_title': spectrum_validators.generate_name_from_title,
+            'user_id_validator': spectrum_validators.user_id_validator
         }
 
     # IPackageContoller
@@ -149,8 +150,9 @@ class SpectrumPlugin(plugins.SingletonPlugin, DefaultPermissionLabels):
 
 def alter_user_schema(default_user_schema):
     @schema.validator_args
-    def spectrum_user_schema(email_is_unique):
+    def spectrum_user_schema(email_is_unique, user_id_validator):
         spectrum_user_schema = default_user_schema()
+        spectrum_user_schema['id'].append(user_id_validator)
         spectrum_user_schema['email'].remove(email_is_unique)
         return spectrum_user_schema
     return spectrum_user_schema

--- a/ckanext/spectrum/plugin.py
+++ b/ckanext/spectrum/plugin.py
@@ -5,6 +5,7 @@ import ckan.plugins.toolkit as toolkit
 import ckan.lib.uploader as uploader
 from ckan.views import _identify_user_default
 from ckan.authz import is_sysadmin
+import ckan.logic.schema as schema
 import ckanext.blob_storage.helpers as blobstorage_helpers
 from ckan.lib.plugins import DefaultPermissionLabels
 from ckanext.spectrum.helpers import (
@@ -47,6 +48,8 @@ class SpectrumPlugin(plugins.SingletonPlugin, DefaultPermissionLabels):
         toolkit.add_template_directory(config_, "templates")
         toolkit.add_public_directory(config_, "public")
         toolkit.add_resource("assets", "spectrum")
+        if (schema.default_user_schema.__name__ != 'spectrum_user_schema'):
+            schema.default_user_schema = alter_user_schema(schema.default_user_schema)
 
     # IFacets
     def dataset_facets(self, facet_dict, package_type):
@@ -142,3 +145,12 @@ class SpectrumPlugin(plugins.SingletonPlugin, DefaultPermissionLabels):
 
             if substitute_user_id:
                 return spectrum_authn.substitute_user(substitute_user_id)
+
+
+def alter_user_schema(default_user_schema):
+    @schema.validator_args
+    def spectrum_user_schema(email_is_unique):
+        spectrum_user_schema = default_user_schema()
+        spectrum_user_schema['email'].remove(email_is_unique)
+        return spectrum_user_schema
+    return spectrum_user_schema

--- a/ckanext/spectrum/tests/test_actions.py
+++ b/ckanext/spectrum/tests/test_actions.py
@@ -9,6 +9,7 @@ from ckan.plugins import toolkit
 
 
 DUMMY_PASSWORD = '01234567890123456789012345678901'
+DUMMY_USERNAME = 'dummy-123'
 
 
 @pytest.fixture
@@ -18,10 +19,17 @@ def mock_token_urlsafe():
         yield mock_token_urlsafe
 
 
+@pytest.fixture
+def mock_random_username():
+    with mock.patch('ckanext.spectrum.actions._get_random_username_from_email',
+                    return_value=DUMMY_USERNAME) as mock_random_username:
+        yield mock_random_username
+
+
 @pytest.mark.usefixtures('clean_db', 'with_plugins')
 class TestCreateUser():
 
-    def test_unit_with_password(self, mock_token_urlsafe):
+    def test_unit_without_autogeneration(self, mock_token_urlsafe):
         next_action = mock.Mock()
         data_dict = {
             'name': 'test_user',
@@ -31,15 +39,19 @@ class TestCreateUser():
         user_create(next_action, {}, data_dict)
         next_action.assert_called_once_with({}, data_dict)
 
-    def test_unit_without_password(self, mock_token_urlsafe):
+    def test_unit_with_autogeneration(self, mock_token_urlsafe, mock_random_username):
         next_action = mock.Mock()
         data_dict = {
-            'name': 'test_user',
             'email': 'test@test.org'
         }
-        user_create(next_action, {}, data_dict)
-        expected_data_dict = {**data_dict, 'password': DUMMY_PASSWORD}
-        next_action.assert_called_once_with({}, expected_data_dict)
+        mock_context = {'model': None}
+        user_create(next_action, mock_context, data_dict)
+        expected_data_dict = {
+            **data_dict,
+            'password': DUMMY_PASSWORD,
+            'name': DUMMY_USERNAME
+        }
+        next_action.assert_called_once_with(mock_context, expected_data_dict)
 
     def test_auto_generated_password_is_strong(self):
         next_action = mock.Mock()
@@ -52,17 +64,16 @@ class TestCreateUser():
         assert len(generated_password) > 30
         assert zxcvbn(generated_password)['score'] == 4
 
-    def test_integration_without_password(self):
-        call_action(
+    def test_integration(self):
+        response = call_action(
             'user_create',
-            name='test_user',
             email='test@test.org'
         )
         sysadmin = factories.User(sysadmin=True)
         response = call_action(
             'user_show',
             get_context(sysadmin['name']),
-            id='test_user',
+            id=response['name'],
             include_password_hash=True
         )
         assert response['password_hash']

--- a/ckanext/spectrum/tests/test_authn.py
+++ b/ckanext/spectrum/tests/test_authn.py
@@ -38,7 +38,7 @@ class TestSysadminsOnlyCanAccessAPI():
     ])
     def test_api_endpoints_require_registered_user(self, app, action):
         response = app.get(
-            toolkit.url_for('api.action', ver=3, logic_function=action),
+            toolkit.url_for('api.action', ver=3, logic_function=action)
         )
         assert response.status_code == 403
         assert response.json == {

--- a/ckanext/spectrum/validators.py
+++ b/ckanext/spectrum/validators.py
@@ -39,8 +39,46 @@ def generate_name_from_title(field, schema):
             alpha_id = ''.join(choice(ascii_lowercase) for i in range(3))
             new_dataset_name = "{}-{}".format(title_slug, alpha_id)
             data[key] = new_dataset_name
-
         else:
             raise ValidationError({'name': [_('Could not autogenerate a unique name.')]})
 
     return validator
+
+
+def user_id_validator(key, data, errors, context):
+    """
+    Validate a new user id.
+
+    The form of this validator is taken from the ckan core validator:
+        user_name_validator
+    """
+    model = context['model']
+    new_user_id = data[key]
+
+    if not isinstance(new_user_id, str):
+        raise ValidationError({'id': [_('User IDs must be strings')]})
+
+    user = model.User.get(new_user_id)
+    user_obj_from_context = context.get('user_obj')
+
+    if user is not None:
+
+        # A user with new_user_id already exists in the database.
+        if user_obj_from_context and user_obj_from_context.name == user.name:
+            # If there's a user_obj in context with the same id as the user
+            # found in the db, then we must be doing a user_update and not
+            # updating the user name, so don't return an error.
+            return
+        else:
+            # Otherwise return an error: there's already another user with that
+            # name, so you can create a new user with that name or update an
+            # existing user's name to that name.
+            errors[key].append(_('That user ID is not available.'))
+
+    elif user_obj_from_context:
+        old_user = model.User.get(user_obj_from_context.id)
+
+        if old_user is not None and old_user.state != model.State.PENDING:
+            errors[key].append(_('The user ID cannot be modified.'))
+        else:
+            return


### PR DESCRIPTION
This PR removes the uniqueness constraint on emails, as requested by Avenir. 

It should allow us to remove the ckanext-emailasusername dependency for the project. 

It allows the generation of user accounts from just an email address. 

In my research for this feature I have realised that the user ID does not have to be unique.  I was suprised by this, but the ID field under default ckan 2.9.5 is just not subject to a uniqueness validator (the name field is). I wonder what we feel about this?  Given Avenir is intending to primarily use IDs to identify users in the system, I have proposed a user_id_validator similar to the existing user_name_validator that ensures the id must be unique. 