### PR TITLE
SPC-91 Add user id to user page

### DIFF
--- a/ckanext/spectrum/templates/user/read_base.html
+++ b/ckanext/spectrum/templates/user/read_base.html
@@ -1,0 +1,15 @@
+{% ckan_extends %}
+
+{% block user_info %}
+
+<div class="info">
+    <dl>
+        <dt>{{ _('User ID') }}</dt>
+        <dd>
+            {{ user.id }}
+        </dd>
+    </dl>
+</div>
+{{ super() }}
+{% endblock %}
+


### PR DESCRIPTION
Very simple tweak to display the user ID on the user page, as requested by Bob. 