### PR TITLE
SPC-93 Substitute user bug

### DIFF
--- a/ckanext/spectrum/authn.py
+++ b/ckanext/spectrum/authn.py
@@ -15,5 +15,5 @@ def substitute_user(substitute_user_id):
             }
         }, 400
 
-    toolkit.g.user = substitute_user_id
+    toolkit.g.user = substitute_user_obj.name
     toolkit.g.userobj = substitute_user_obj

--- a/ckanext/spectrum/tests/test_authn.py
+++ b/ckanext/spectrum/tests/test_authn.py
@@ -83,7 +83,8 @@ class TestSubstituteUser():
             }
         }
 
-    def test_valid_substitute_user_request(self, app):
+    @pytest.mark.parametrize("user_field", ["id", "name"])
+    def test_valid_substitute_user_request(self, app, user_field):
         sysadmin_user = factories.User(sysadmin=True)
         substitute_user = factories.User()
         dataset = factories.Dataset()
@@ -98,7 +99,7 @@ class TestSubstituteUser():
             json={'name': 'test-dataset'},
             headers={
                 'Authorization': sysadmin_user['apikey'],
-                'CKAN-Substitute-User': substitute_user['name']
+                'CKAN-Substitute-User': substitute_user[user_field]
             }
         )
         assert response.status_code == 200


### PR DESCRIPTION
Fixes a bug raised by Andrew where the Substitute user feature was failing for user IDs, but working for user names. 