### PR TITLE
SPC-99 Typo fix.

### DIFF
--- a/ckanext/spectrum/plugin.py
+++ b/ckanext/spectrum/plugin.py
@@ -75,7 +75,7 @@ class SpectrumPlugin(plugins.SingletonPlugin, DefaultPermissionLabels):
         organisation, whilst ensuring they remain visible to the creator user.
 
         This function is extending the default parent class behaviour found
-        in ckan.lib.plugins.DefaultPermissionLabels.  We remove the label
+        in ckan.lib.plugins.DefaultPermissionLabels. We remove the label
         identifying the dataset as a member of the parent organisation, and
         replace it with the label identifying the creator user id.
         """


### PR DESCRIPTION
Let's see if this merge causes following tests to fail:

TestUserIDValidator.test_user_id_uniqueness
TestUserIDValidator.test_id_cannot_match_existing_username