### PR TITLE
SPC-104-delete-activities

### DIFF
--- a/ckanext/spectrum/plugin.py
+++ b/ckanext/spectrum/plugin.py
@@ -112,6 +112,10 @@ class SpectrumPlugin(plugins.SingletonPlugin, DefaultPermissionLabels):
         }
 
     # IPackageContoller
+    def after_delete(self, context, data_dict):
+        if data_dict.get('private'):
+            spectrum_upload.add_activity(context, data_dict, "changed")
+
     def after_update(self, context, data_dict):
         if data_dict.get('private'):
             spectrum_upload.add_activity(context, data_dict, "changed")

--- a/ckanext/spectrum/tests/test_plugin.py
+++ b/ckanext/spectrum/tests/test_plugin.py
@@ -43,3 +43,22 @@ class TestPrivateDatasetActivities():
             id=private_dataset['id']
         )
         assert len(activity_stream) == 1
+
+    def test_activity_is_created_when_deleting_private_dataset(self):
+        user = factories.User()
+        private_dataset = factories.Dataset(
+            private=True,
+            owner_org=factories.Organization()['id'],
+            creator_user_id=user['id']
+        )
+        call_action(
+            'package_delete',
+            get_context(user['name']),
+            id=private_dataset['id']
+        )
+        activity_stream = call_action(
+            'package_activity_list',
+            get_context(user['name']),
+            id=private_dataset['id']
+        )
+        assert len(activity_stream) == 1


### PR DESCRIPTION

## Description
https://fjelltopp.atlassian.net/browse/SPC-104?atlOrigin=eyJpIjoiOGY2OWYyZWQ3ZjZkNDFlNGE3MWI0NTAxNmI4YzI3ZmIiLCJwIjoiaiJ9

By default CKAN doesn't keep activities for private datasets.  This change just ensures that an activity is recorded after deleting a private dataset. 

## Testing (delete if not applicable)

I have included a regression test of the same structure that tests for activities created after creating and updating a private dataset. 

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [x] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
