### PR TITLE
SPC-140 Allow collaborators to delete themselves

### DIFF
--- a/ckanext/spectrum/authz.py
+++ b/ckanext/spectrum/authz.py
@@ -16,9 +16,25 @@ def creators_manage_collaborators(next_auth, context, data_dict):
 
     if package.creator_user_id == user_obj.id:
         return {'success': True}
-
     else:
         return next_auth(context, data_dict)
+
+
+@toolkit.chained_auth_function
+def package_collaborator_delete(next_auth, context, data_dict):
+    """
+    Explicitly ensures that dataset collaborators can delete themselves.
+    """
+    model = context['model']
+    current_user = context['user']
+    requested_user = toolkit.get_or_bust(data_dict, 'user_id')
+    current_user_obj = model.User.get(current_user)
+    requested_user_obj = model.User.get(requested_user)
+
+    if current_user_obj.id == requested_user_obj.id:
+        return {'success': True}
+    else:
+        return creators_manage_collaborators(next_auth, context, data_dict)
 
 
 @toolkit.auth_disallow_anonymous_access

--- a/ckanext/spectrum/plugin.py
+++ b/ckanext/spectrum/plugin.py
@@ -99,8 +99,8 @@ class SpectrumPlugin(plugins.SingletonPlugin, DefaultPermissionLabels):
         return {
             'package_update': spectrum_authz.package_update,
             'package_collaborator_create': spectrum_authz.creators_manage_collaborators,
-            'package_collaborator_delete': spectrum_authz.creators_manage_collaborators,
-            'package_collaborator_list': spectrum_authz.creators_manage_collaborators
+            'package_collaborator_list': spectrum_authz.creators_manage_collaborators,
+            'package_collaborator_delete': spectrum_authz.package_collaborator_delete
         }
 
     # IActions

--- a/ckanext/spectrum/tests/test_authz.py
+++ b/ckanext/spectrum/tests/test_authz.py
@@ -149,3 +149,17 @@ class TestAuth():
             id=datasets[0]['id'],
             user_id=users[1]['id']
         )
+
+    def test_collaborator_can_delete_self(self, users, datasets):
+        call_action(
+            'package_collaborator_create',
+            id=datasets[0]['id'],
+            user_id=users[1]['id'],
+            capacity='editor'
+        )
+        assert call_auth(
+            'package_collaborator_delete',
+            get_context(users[1]),
+            id=datasets[0]['id'],
+            user_id=users[1]['id']
+        )


### PR DESCRIPTION
## Description

Avenir would like collaborators to be able to delete themselves.  This Pr adds a chained auth function that checks if someone is trying to delete themselves as a collaborator on a dataset.  If they are, the auth check passes. 

A small push back on this - the only way of undoing the action is to have the dataset re-shared with the individual. I suspect that an ideal engineering solution to this problem would actually maintain a seperate list of rejected shares (or alternatively think of them as "hidden shares"). So that the user can undo the decision without bothering the dataset creator if they so choose.  That way you preserve the integrity of the list of collaborators being "the list of people the dataset owner is happy to share the data with". 

But I appreciate this may be more work and complexity than it is worth. 

## Testing

A test is included for this new feature. 

## Documentation

Small updates have been made to the API documentation [here](https://documenter.getpostman.com/view/15920939/UzBpK5q9#05c2972e-e059-4579-8fcc-0b851a2752ab). 

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [x] My code follows the general Fjelltopp documentation (see Confluence).
- [x] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [x] I have rebased this branch with master.
- [x] New dependency changes have been committed.
- [x] I have added automated tests that prove my fix is effective or that my feature works.
- [x] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
